### PR TITLE
fix bug - checker register duplicate functions to event bus

### DIFF
--- a/lyrebird/__init__.py
+++ b/lyrebird/__init__.py
@@ -6,14 +6,12 @@ from .mock import plugin_manager
 from blinker import Signal
 import os
 from .event import CustomEventReceiver
+from .checker import event
 from lyrebird import application
 from lyrebird.log import get_logger
 
 
 APPLICATION_CONF_DIR = os.path.join(os.path.expanduser('~'), '.lyrebird')
-
-
-event = CustomEventReceiver()
 
 
 def start_background_task(target, *args, **kwargs):

--- a/lyrebird/checker.py
+++ b/lyrebird/checker.py
@@ -17,7 +17,7 @@ registered_func_array = []
 
 class CheckerEventHandler:
 
-    def __call__(self, channel, object=False, *args, **kw):
+    def __call__(self, channel, *args, **kw):
         def func(origin_func):
             registered_func_array.append([channel, origin_func])
             return origin_func

--- a/lyrebird/checker.py
+++ b/lyrebird/checker.py
@@ -12,6 +12,28 @@ from lyrebird.event import CustomEventReceiver
 logger = log.get_logger()
 
 
+registered_func_array = []
+
+
+class CheckerEventHandler:
+
+    def __call__(self, channel, object=False, *args, **kw):
+        def func(origin_func):
+            registered_func_array.append([channel, origin_func])
+            return origin_func
+        return func
+
+    def issue(self, title, message):
+        notice = {
+            "title": title,
+            "message": message
+        }
+        application.server['event'].publish('notice', notice)
+
+
+event = CheckerEventHandler()
+
+
 class LyrebirdCheckerServer(ThreadServer):
     def __init__(self):
         super().__init__()
@@ -133,11 +155,18 @@ class Checker:
         self._update = val
 
     def activate(self):
+        global registered_func_array
         self._module = script_module = self.load_class(self.path)
         event_proxy = getattr(script_module, 'event')
         if isinstance(event_proxy, CustomEventReceiver):
             self._event_receiver = event_proxy
             event_proxy.register(context.application.event_bus)
+        elif isinstance(event_proxy, CheckerEventHandler):
+            self._event_receiver = CustomEventReceiver()
+            for registered_func in registered_func_array:
+                self._event_receiver.listeners.append(dict(channel=registered_func[0], func=registered_func[1]))
+            self._event_receiver.register(context.application.event_bus)
+            registered_func_array = []
         self.activated = True
 
     def deactivate(self):

--- a/lyrebird/event.py
+++ b/lyrebird/event.py
@@ -23,6 +23,7 @@ class Event:
     """
     Event bus inner class
     """
+
     def __init__(self, event_id, channel, message):
         self.id = event_id
         self.channel = channel
@@ -40,7 +41,6 @@ class EventServer(ThreadServer):
         self.any_channel = []
         self.broadcast_executor = ThreadPoolExecutor(thread_name_prefix='event-broadcast-')
 
-
     def broadcast_handler(self, callback_fn, event, args, kwargs):
         """
 
@@ -49,7 +49,7 @@ class EventServer(ThreadServer):
         # Check
         func_sig = inspect.signature(callback_fn)
         func_parameters = list(func_sig.parameters.values())
-        if len(func_parameters)<1 or func_parameters[0].default!=inspect._empty:
+        if len(func_parameters) < 1 or func_parameters[0].default != inspect._empty:
             logger.error(f'Event callback function [{callback_fn.__name__}] need a argument for receiving event object')
             return
 
@@ -108,7 +108,7 @@ class EventServer(ThreadServer):
         # Make sure event is dict
         if not isinstance(message, dict):
             # Plugins send a array list as message, then set this message to raw property
-            _msg = { 'raw': message }
+            _msg = {'raw': message}
             message = _msg
 
         message['channel'] = channel
@@ -150,7 +150,6 @@ class EventServer(ThreadServer):
             callback_fn_list = self.pubsub_channels.setdefault(channel, [])
             callback_fn_list.append([callback_fn, args, kwargs])
 
-
     def unsubscribe(self, channel, target_callback_fn, *args, **kwargs):
         """
         Unsubscribe callback function from channel
@@ -178,6 +177,7 @@ class CustomEventReceiver:
         def on_message(data):
             pass
     """
+
     def __init__(self):
         self.listeners = []
 
@@ -202,5 +202,5 @@ class CustomEventReceiver:
         notice = {
             "title": title,
             "message": message
-            }
+        }
         application.server['event'].publish('notice', notice)

--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (1, 6, 14)
+IVERSION = (1, 6, 15)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION


### PR DESCRIPTION
If you use lyrebird.event for register your checker function. Lyrebird will register duplicate callback functions to event bus.

```
from lyrebird import event

@event('flow')
def my_callback(msg):
    pass
```