### PR TITLE
fix keyerror -children

### DIFF
--- a/lyrebird/mock/dm.py
+++ b/lyrebird/mock/dm.py
@@ -257,6 +257,8 @@ class DataManager:
             'super_id': None
         }
         # New group added in the head of child list
+        if 'children' not in parent_node:
+            parent_node['children'] = []
         parent_node['children'].insert(0, new_group)
         # Register ID
         self.id_map[group_id] = new_group

--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (1, 7, 3)
+IVERSION = (1, 7, 4)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION


### PR DESCRIPTION
**Fix**

Add group to empty mock data dir failed with "Key Error" （children not found）