### PR TITLE
bugfix/datamanager-mock-rules-support-type

### DIFF
--- a/frontend/src/api/inspector.js
+++ b/frontend/src/api/inspector.js
@@ -1,0 +1,7 @@
+import axios from 'axios'
+
+export const getFlowMode = () => {
+    return axios({
+        url: '/api/mode'
+    })
+}

--- a/frontend/src/api/inspector.js
+++ b/frontend/src/api/inspector.js
@@ -1,7 +1,0 @@
-import axios from 'axios'
-
-export const getFlowMode = () => {
-    return axios({
-        url: '/api/mode'
-    })
-}

--- a/lyrebird/mock/dm.py
+++ b/lyrebird/mock/dm.py
@@ -190,6 +190,8 @@ class DataManager:
         result = flow
         for prop_key in prop_keys:
             result = result.get(prop_key)
+            if not isinstance(result, dict):
+                return
             if not result:
                 return None
         return result

--- a/lyrebird/mock/dm.py
+++ b/lyrebird/mock/dm.py
@@ -189,9 +189,9 @@ class DataManager:
         prop_keys = rule_key.split('.')
         result = flow
         for prop_key in prop_keys:
-            result = result.get(prop_key)
             if not isinstance(result, dict):
                 return
+            result = result.get(prop_key)
             if not result:
                 return None
         return result


### PR DESCRIPTION
- Fix error when matching-rule of mock data matches non-dictionary data