### PR TITLE
bugfix/notice-badge-not-display-with-empty-noticeList

### DIFF
--- a/frontend/src/views/notice/NoticeCenter.vue
+++ b/frontend/src/views/notice/NoticeCenter.vue
@@ -3,6 +3,7 @@
     <v-badge
       color="error"
       :content="noticeList.length > 999 ? '999+' : noticeList.length"
+      :value="noticeList.length"
       offset-x="10"
       offset-y="8"
     >


### PR DESCRIPTION
- Not display notice badge with an empty notice list