### PR TITLE
bugfix: lb proxy protocol parser error

### DIFF
--- a/e2e_tests/Readme.md
+++ b/e2e_tests/Readme.md
@@ -1,8 +1,13 @@
 # lyrebird e2e test
+
 ## 测试 lyrebird（POST）request body
 
 ```bash
-nohup python3 serve.py > /dev/null 2>&1 & 
-nohup lyrebird -b > /dev/null 2>&1 & 
+pip install -e .[dev]
+# If you are using zsh you need to escape square brackets or use quotes:
+# pip install -e .\[extra\]
+# or
+# pip install -e ".[extra]"
+cd e2e_tests
 python -m pytest .
 ```

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -68,6 +68,7 @@ class Lyrebird:
         self.extra_mock_port = None
         self.api_status = None
         self.uri_mock = None
+        self.uri_extra_mock = None
         self._init_port()
 
     def _init_port(self):
@@ -76,6 +77,7 @@ class Lyrebird:
         self.extra_mock_port = self._find_free_port()
         self.api_status = f'http://127.0.0.1:{self.port}/api/status'
         self.uri_mock = f'http://127.0.0.1:{self.port}/mock/'
+        self.uri_extra_mock = f'http://127.0.0.1:{self.extra_mock_port}/'
 
     def _find_free_port(self):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -91,6 +91,7 @@ class Lyrebird:
             cmdline = cmdline + f' --script {checker_path}'
         self.lyrebird_process = subprocess.Popen(cmdline, shell=True, start_new_session=True)
         _wait(requests.get, args=[self.api_status])
+        _wait(requests.get, args=[self.uri_extra_mock])
 
         # Wait for checker to load
         if checker_path:

--- a/e2e_tests/test_core.py
+++ b/e2e_tests/test_core.py
@@ -1,5 +1,10 @@
 import pytest
-import os, hashlib, json, gzip, requests
+import os
+import hashlib
+import json
+import gzip
+import requests
+from urllib.parse import quote
 
 
 curPath = os.path.abspath(os.path.dirname(__file__))
@@ -11,6 +16,7 @@ def test_img_data(lyrebird, mock_server):
     r = requests.post(url=lyrebird.uri_mock + mock_server.api_post, data=data)
     assert r.text == hashlib.md5(mock_server.api_post.encode() + data).hexdigest()
 
+
 def test_img_file(lyrebird, mock_server):
     files = {'file': ('1.png', open(f'{curPath}/assets/1.png', 'rb'), 'image/jpg')}
     r = requests.post(url=lyrebird.uri_mock + mock_server.api_post, files=files)
@@ -18,11 +24,13 @@ def test_img_file(lyrebird, mock_server):
         data = f.read()
     assert r.text == hashlib.md5(mock_server.api_post.encode() + data).hexdigest()
 
+
 def test_json(lyrebird, mock_server):
     data = json.dumps({"name": {"12": 123}}, ensure_ascii=False)
     headers = {"Content-Type": "application/json"}
     r = requests.post(url=lyrebird.uri_mock + mock_server.api_post, data=data, headers=headers)
     assert r.text == hashlib.md5(mock_server.api_post.encode() + data.encode()).hexdigest()
+
 
 def test_text(lyrebird, mock_server):
     data = "asdasdasd"
@@ -30,11 +38,13 @@ def test_text(lyrebird, mock_server):
     r = requests.post(url=lyrebird.uri_mock + mock_server.api_post, data=data, headers=headers)
     assert r.text == hashlib.md5(mock_server.api_post.encode() + data.encode()).hexdigest()
 
+
 def test_form(lyrebird, mock_server):
     data = 'z=9&a=1&a=2&b=1'
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     r = requests.post(url=lyrebird.uri_mock + mock_server.api_post, data=data, headers=headers)
     assert r.text == hashlib.md5(mock_server.api_post.encode() + data.encode()).hexdigest()
+
 
 def test_json_gzip(lyrebird, mock_server):
     data = {"a": 1}
@@ -42,3 +52,23 @@ def test_json_gzip(lyrebird, mock_server):
     headers = {"Content-Type": "application/json", "Content-Encoding": "gzip"}
     r = requests.post(url=lyrebird.uri_mock + mock_server.api_post, data=ziped_data, headers=headers)
     assert r.text == hashlib.md5(mock_server.api_post.encode() + ziped_data).hexdigest()
+
+
+def test_lb_proxy_protocol_target_in_path(lyrebird, mock_server):
+    r = requests.get(url=lyrebird.uri_extra_mock + mock_server.api_status)
+    assert r.text == 'OK'
+
+
+def test_lb_proxy_protocol_target_in_header(lyrebird, mock_server):
+    headers = {
+        'MKScheme': 'http',
+        'MKOriginHost': '127.0.0.1',
+        'MKOriginPort': '5000'
+    }
+    r = requests.get(url=lyrebird.uri_extra_mock + 'status', headers=headers)
+    assert r.text == 'OK'
+
+
+def test_lb_proxy_protocol_target_in_query(lyrebird, mock_server):
+    r = requests.get(url=lyrebird.uri_extra_mock + f'?proxy={quote(mock_server.api_status)}')
+    assert r.text == 'OK'

--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (2, 6, 0)
+IVERSION = (2, 6, 1)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION


### PR DESCRIPTION
Set origin url in custom args, if this url not in filter list, lyrebird proxy got wrong url.

------
curl http://127.0.0.1:9999/?proxy=http://www.baidu.com

lyrebird parse wrong url like ?proxy=http://www.baidu.com
