### PR TITLE
Add new lyrebird proxy protocol

### DIFF
--- a/e2e_tests/assets/serve.py
+++ b/e2e_tests/assets/serve.py
@@ -14,9 +14,11 @@ def e2e_test():
         return hashlib.md5(request.url.encode() + req_body).hexdigest()
     return hashlib.md5(request.url.encode() + req_body).hexdigest()
 
+
 @app.route("/status", methods=["GET"])
 def status():
     return "OK"
+
 
 if __name__ == "__main__":
     port = 5000

--- a/e2e_tests/test_core.py
+++ b/e2e_tests/test_core.py
@@ -1,3 +1,4 @@
+from importlib.resources import path
 import pytest
 import os
 import hashlib
@@ -71,4 +72,11 @@ def test_lb_proxy_protocol_target_in_header(lyrebird, mock_server):
 
 def test_lb_proxy_protocol_target_in_query(lyrebird, mock_server):
     r = requests.get(url=lyrebird.uri_extra_mock + f'?proxy={quote(mock_server.api_status)}')
+    assert r.text == 'OK'
+
+
+def test_lb_proxy_protocol_target_in_query_2(lyrebird, mock_server):
+    host = quote(f'127.0.0.1:{mock_server.port}')
+    path = quote('/status')
+    r = requests.get(url=lyrebird.uri_extra_mock + f'?proxyscheme=http&proxyhost={host}&proxypath={path}&a=1')
     assert r.text == 'OK'

--- a/lyrebird/mock/extra_mock_server/__init__.py
+++ b/lyrebird/mock/extra_mock_server/__init__.py
@@ -1,0 +1,28 @@
+
+import multiprocessing
+
+from lyrebird import application
+from lyrebird.log import get_logger
+from .server import serve
+
+
+logger = get_logger()
+
+
+class ExtraMockServer():
+    def __init__(self) -> None:
+        self._server_process = None
+
+    def start(self):
+        self._server_process = multiprocessing.Process(
+            group=None,
+            daemon=True,
+            target=serve,
+            kwargs={'config': application.config.raw()})
+        self._server_process.start()
+
+    def stop(self):
+        if self._server_process:
+            self._server_process.terminate()
+            logger.warning(f'MockServer shutdown')
+            self._server_process = None

--- a/lyrebird/mock/extra_mock_server/lyrebird_proxy_protocol.py
+++ b/lyrebird/mock/extra_mock_server/lyrebird_proxy_protocol.py
@@ -120,6 +120,7 @@ class LyrebirdProxyContext:
         if not proxy_host:
             return
 
+        # remove lyrebrid proxy protocol keys from query string
         origin_query_str = ''
         for query_key, query_value in request.query.items():
             if query_key in ['proxyscheme', 'proxyhost', 'proxypath']:
@@ -127,7 +128,8 @@ class LyrebirdProxyContext:
             origin_query_str += f'&{query_key}={query_value}'
         if len(origin_query_str) >= 1:
             origin_query_str = '?'+origin_query_str[1:]
-        origin_url = f'{proxy_scheme}://{proxy_host}{proxy_path}{origin_query_str}'
+
+        origin_url = f'{proxy_scheme}://{urlparse.unquote(proxy_host)}{urlparse.unquote(proxy_path)}{origin_query_str}'
 
         self.origin_url = origin_url
         url = urlparse.urlparse(origin_url)

--- a/lyrebird/mock/extra_mock_server/lyrebird_proxy_protocol.py
+++ b/lyrebird/mock/extra_mock_server/lyrebird_proxy_protocol.py
@@ -1,0 +1,151 @@
+from aiohttp import web, client
+from typing import List, Set, Optional
+from urllib import parse as urlparse
+
+
+class UnknownLyrebirdProxyProtocol(Exception):
+    pass
+
+
+class LyrebirdProxyContext:
+    def __init__(self):
+        self.request: web.Request = None
+        self.netloc = None
+        self.origin_url = None
+        self.forward_url = None
+        self.init = False
+        self.protocol_parsers = [
+            self.protocol_read_from_path,
+            self.protocol_read_from_header,
+            self.protocol_read_from_query,
+            self.protocol_read_from_query_2
+        ]
+
+    def protocol_read_from_path(self, request: web.Request, lb_config):
+        # Lyrebird proxy protocol #1
+        # Origin target info in path
+        # e.g.
+        # http://{lyrebird_host}/{origin_full_url}
+
+        if not request.path.startswith('/http://') and not request.path.startswith('/https://'):
+            return
+
+        origin_full_url = request.path_qs[1:]
+        url = urlparse.urlparse(origin_full_url)
+
+        # origin url for proxy
+        self.origin_url = origin_full_url
+        # forward url to lyrebird main port 'default 9090'
+        port = lb_config.get('mock.port')
+        self.forward_url = f'http://127.0.0.1:{port}/mock/{origin_full_url}'
+
+        self.netloc = url.netloc
+        self.request = request
+
+        # Set init success
+        self.init = True
+
+    def protocol_read_from_header(self, request: web.Request, lb_config):
+        # Lyrebird proxy protocol #2
+        # Origin target info in headers
+        # e.g.
+        # http://{lyrebird_host}/{origing_path_and_query}
+        # headers:
+        # MKScheme: {origin_scheme}
+        # MKOriginHost: {origin_host}
+        # MKOriginPort: {origin_port}
+        header_name_scheme = lb_config.get('mock.proxy_headers', {}).get('scheme')
+        header_name_host = lb_config.get('mock.proxy_headers', {}).get('host')
+        header_name_port = lb_config.get('mock.proxy_headers', {}).get('port')
+
+        if not request.headers.get(header_name_host) or not request.headers.get(header_name_scheme):
+            return
+
+        target_scheme = request.headers.get(header_name_scheme)
+        target_host = request.headers.get(header_name_host)
+        target_port = request.headers.get(header_name_port)
+        if target_port:
+            origin_full_url = f'{target_scheme}://{target_host}:{target_port}{request.rel_url}'
+            netloc = f'{target_host}:{target_port}'
+        else:
+            origin_full_url = f'{target_scheme}://{target_host}{request.rel_url}'
+            netloc = target_host
+
+        # origin url for proxy
+        self.origin_url = origin_full_url
+        # forward url to lyrebird main port 'default 9090'
+        port = lb_config.get('mock.port')
+        self.forward_url = f'http://127.0.0.1:{port}/mock/{origin_full_url}'
+        self.netloc = netloc
+        self.request = request
+
+        # Set init success
+        self.init = True
+
+    def protocol_read_from_query(self, request: web.Request, lb_config):
+        # Lyrebird proxy protocol #3
+        # Origin target info in query
+        # key is "proxy"
+        # e.g.
+        # http://{lyrebird_host}/{origing_path}?{proxy=encoded-url}
+
+        # default key=proxy
+        if not request.query.get('proxy'):
+            return
+
+        origin_url = request.query.get('proxy')
+        origin_url = urlparse.unquote(origin_url)
+        url = urlparse.urlparse(origin_url)
+
+        self.origin_url = origin_url
+        # forward url to lyrebird main port 'default 9090'
+        port = lb_config.get('mock.port')
+        self.forward_url = f'http://127.0.0.1:{port}/mock/?proxy={urlparse.quote(origin_url)}'
+        self.netloc = url.netloc
+        self.request = request
+
+        # Set init success
+        self.init = True
+
+    def protocol_read_from_query_2(self, request: web.Request, lb_config):
+        # Lyrebird proxy protocol #4
+        # Origin target info in query
+        # Set proxyscheme、proxyhost、proxypath
+        # e.g.
+        # http://{lyrebird_host}?proxyscheme={origin_scheme}&proxyhost={urlencode(origin_host)}&proxypath={urlencode(origin_path)}&{origin_query}
+        proxy_scheme = request.query.get('proxyscheme', 'http')
+        proxy_host = request.query.get('proxyhost', None)
+        proxy_path = request.query.get('proxypath', '/')
+
+        if not proxy_host:
+            return
+
+        origin_query_str = ''
+        for query_key, query_value in request.query.items():
+            if query_key in ['proxyscheme', 'proxyhost', 'proxypath']:
+                continue
+            origin_query_str += f'&{query_key}={query_value}'
+        if len(origin_query_str) >= 1:
+            origin_query_str = '?'+origin_query_str[1:]
+        origin_url = f'{proxy_scheme}://{proxy_host}{proxy_path}{origin_query_str}'
+
+        self.origin_url = origin_url
+        url = urlparse.urlparse(origin_url)
+
+        # forward url to lyrebird main port 'default 9090'
+        port = lb_config.get('mock.port')
+        self.forward_url = f'http://127.0.0.1:{port}/mock/{origin_url}'
+        self.netloc = url.netloc
+        self.request = request
+
+        # Set init success
+        self.init = True
+
+    @classmethod
+    def parse(cls, request: web.Request, lb_config):
+        ctx = cls()
+        for parser in ctx.protocol_parsers:
+            parser(request, lb_config)
+            if ctx.init:
+                return ctx
+        raise UnknownLyrebirdProxyProtocol

--- a/lyrebird/mock/mock_server.py
+++ b/lyrebird/mock/mock_server.py
@@ -76,9 +76,16 @@ class LyrebirdMockServer(ThreadServer):
 
         @self.app.errorhandler(Exception)
         def on_app_error(error):
-            _logger.error(
-                f'[mocker server exception]:\nOn request {request.url}\n{error.__class__.__name__} {error}\n{traceback.format_exc()}')
-            return application.make_fail_response(f'{error.__class__.__name__} {error}\n{traceback.format_exc()}')
+            trace = traceback.format_exc()
+            try:
+                _logger.error(f'[mock server exception]: {trace}')
+                _logger.error(f'[mock server exception]: {request.url}')
+                _logger.error(f'[mock server exception]: {error}')
+            except:
+                # error handler must not raise any exceptions!
+                pass
+
+            return application.make_fail_response(f'Mock server error:\n {trace}')
 
     def run(self):
         server_ip = application.config.get('ip')

--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (2, 6, 2)
+IVERSION = (2, 7, 0)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION

--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (2, 6, 1)
+IVERSION = (2, 6, 2)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION


### PR DESCRIPTION
**New:**
New lyrebird proxy protocol
```
http://{lyrbeird-host}:{prot}/?proxyscheme={origin-scheme}&proxyhost={urlencode(origin-host)}&proxypath={urlencode(origin-path)}${origin-query}
```

**Fix:**
mock server errorhandler crash