### PR TITLE
 Fixed an issue where packages could not be reintroduced

### DIFF
--- a/lyrebird/plugins/plugin_loader.py
+++ b/lyrebird/plugins/plugin_loader.py
@@ -12,6 +12,7 @@ from ..log import get_logger
 from .plugin import Plugin
 
 from lyrebird import application
+import sys
 
 logger = get_logger()
 
@@ -135,6 +136,8 @@ def load_from_path(plugin_path):
         manifest_file = Path(plugin_path)/pkg/'manifest.py'
         if not manifest_file.exists():
             continue
+        sys.modules.pop(pkg)
+        sys.modules.pop(pkg+'.manifest')
         imp.load_package(pkg, Path(plugin_path)/pkg)
         __import__(pkg+'.manifest')
 

--- a/lyrebird/plugins/plugin_loader.py
+++ b/lyrebird/plugins/plugin_loader.py
@@ -136,8 +136,10 @@ def load_from_path(plugin_path):
         manifest_file = Path(plugin_path)/pkg/'manifest.py'
         if not manifest_file.exists():
             continue
-        sys.modules.pop(pkg)
-        sys.modules.pop(pkg+'.manifest')
+        if pkg in sys.modules:
+            sys.modules.pop(pkg)
+        if pkg+'.manifest' in sys.modules:
+            sys.modules.pop(pkg+'.manifest')
         imp.load_package(pkg, Path(plugin_path)/pkg)
         __import__(pkg+'.manifest')
 


### PR DESCRIPTION
Debug has a plug-in Times ManifestError, indicating that the plugin developed by itself has not been loaded  
 
Python does not import a package with the same name  
 
Sys.modules.pop (< package name >) if you want to rereference a package of the same name in a particular location 