### PR TITLE
bugfix/jinja2-format-missing-tail-n

### DIFF
--- a/lyrebird/mock/handlers/http_data_helper/__init__.py
+++ b/lyrebird/mock/handlers/http_data_helper/__init__.py
@@ -17,7 +17,7 @@ flow2origin_handlers = OrderedDict({
 class DataHelper:
 
     @staticmethod
-    def origin2flow(origin_obj, output=None):
+    def origin2flow(origin_obj, output=None, chain=None):
         if not origin_obj:
             return
 
@@ -34,7 +34,7 @@ class DataHelper:
 
         for headers_key, func in origin2flow_handlers.items():
             headers_val = raw_headers.get(headers_key, '')
-            _data = func.origin2flow(headers_val, _data)
+            _data = func.origin2flow(headers_val, _data, chain=chain)
 
         if output:
             output['data'] = _data
@@ -42,14 +42,18 @@ class DataHelper:
             return _data
 
     @staticmethod
-    def flow2origin(flow_obj, output=None):
+    def flow2origin(flow_obj, output=None, chain=None):
         _data = flow_obj.get('data')
-        if not _data:
+        if _data is None:
             return
 
-        for headers_key, func in flow2origin_handlers.items():
-            headers_val = flow_obj['headers'].get(headers_key, '')
-            _data = func.flow2origin(headers_val, _data)
+        if chain:
+            for func in chain:
+                _data = func.flow2origin(_data)
+        else:
+            for headers_key, func in flow2origin_handlers.items():
+                headers_val = flow_obj['headers'].get(headers_key, '')
+                _data = func.flow2origin(headers_val, _data)
 
         if output:
             output.data = _data

--- a/lyrebird/mock/handlers/http_data_helper/__init__.py
+++ b/lyrebird/mock/handlers/http_data_helper/__init__.py
@@ -48,7 +48,7 @@ class DataHelper:
             return
 
         if chain:
-            for func in chain:
+            for func in chain[::-1]:
                 _data = func.flow2origin(_data)
         else:
             for headers_key, func in flow2origin_handlers.items():

--- a/lyrebird/mock/handlers/http_data_helper/content_encoding/__init__.py
+++ b/lyrebird/mock/handlers/http_data_helper/content_encoding/__init__.py
@@ -13,13 +13,17 @@ def _get_matched_action(content_encoding_name):
         return content_encoding_handlers[content_encoding_name]
     return DefaultHandler
 
-def origin2flow(content_encoding, request_data):
+def origin2flow(content_encoding, request_data, chain=None):
     func = _get_matched_action(content_encoding)
     try:
         _data = func.origin2flow(request_data)
     except Exception as e:
-        _data = DefaultHandler.origin2flow(request_data)
+        func = DefaultHandler
+        _data = func.origin2flow(request_data)
         logger.warning(f'Convert Content-Encoding: {content_encoding} data origin2flow failed! {e}')
+    finally:
+        chain.append(func)
+
     return _data
 
 def flow2origin(content_encoding, flow_data):

--- a/lyrebird/mock/handlers/http_data_helper/content_type/__init__.py
+++ b/lyrebird/mock/handlers/http_data_helper/content_type/__init__.py
@@ -18,13 +18,17 @@ def _get_matched_action(content_type):
             return func
     return DefaultHandler
 
-def origin2flow(content_type, request_data):
+def origin2flow(content_type, request_data, chain=None):
     func = _get_matched_action(content_type)
     try:
         _data = func.origin2flow(request_data)
     except Exception as e:
-        _data = DefaultHandler.origin2flow(request_data)
+        func = DefaultHandler
+        _data = func.origin2flow(request_data)
         logger.warning(f'Convert Content-Type: {content_type} data origin2flow failed! {e}')
+    finally:
+        chain.append(func)
+
     return _data
 
 def flow2origin(content_type, flow_data):

--- a/lyrebird/mock/handlers/http_header_helper/__init__.py
+++ b/lyrebird/mock/handlers/http_header_helper/__init__.py
@@ -29,13 +29,13 @@ class HeadersHelper:
             return _headers
 
     @staticmethod
-    def flow2origin(flow_obj, output=None):
+    def flow2origin(flow_obj, output=None, chain=None):
         _headers = flow_obj.get('headers')
         if not _headers:
             return
 
         for headers_key, func in flow2origin_handlers.items():
-            _headers[headers_key] = func.flow2origin(flow_obj)
+            _headers[headers_key] = func.flow2origin(flow_obj, chain=chain)
 
         if output:
             output.headers = _headers

--- a/lyrebird/mock/handlers/http_header_helper/content_length.py
+++ b/lyrebird/mock/handlers/http_header_helper/content_length.py
@@ -11,8 +11,8 @@ class ContentLengthHandler:
         return str(len(_resp_data))
 
     @staticmethod
-    def flow2origin(flow_obj):
-        _resp_data = DataHelper.flow2origin(flow_obj)
+    def flow2origin(flow_obj, chain=None):
+        _resp_data = DataHelper.flow2origin(flow_obj, chain=chain)
         if not _resp_data:
             return '0'
         return str(len(_resp_data))

--- a/lyrebird/utils.py
+++ b/lyrebird/utils.py
@@ -147,7 +147,7 @@ def render(data):
     }
 
     try:
-        template_data = Template(data)
+        template_data = Template(data, keep_trailing_newline=True)
         return template_data.render(params)
     except Exception:
         logger.error(f'Format error!\n {traceback.format_exc()}')

--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (2, 9, 1)
+IVERSION = (2, 9, 2)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION


### PR DESCRIPTION
- Wrong content length when request body is empty dictionary
- Missing trailing newline when rendering mock data with jinja2
- Unable to recover unparseable request body when proxying