### PR TITLE
bugfix/encode-and-decoder-init-with-no-rank

### DIFF
--- a/frontend/src/views/checker/CheckerDetail.vue
+++ b/frontend/src/views/checker/CheckerDetail.vue
@@ -44,10 +44,10 @@ export default {
       codeType: 'python'
     }
   },
-  mounted () {
-  this.$bus.$on('keydown', this.onKeyDown)
+  activated () {
+    this.$bus.$on('keydown', this.onKeyDown)
   },
-  beforeDestroy () {
+  deactivated () {
     this.$bus.$off('keydown', this.onKeyDown)
   },
   computed: {

--- a/frontend/src/views/datamanager/DataDetailFolder.vue
+++ b/frontend/src/views/datamanager/DataDetailFolder.vue
@@ -115,6 +115,12 @@ export default {
   beforeDestroy () {
     this.$bus.$off('keydown', this.onKeyDown)
   },
+  activated () {
+    this.$bus.$on('keydown', this.onKeyDown)
+  },
+  deactivated () {
+    this.$bus.$off('keydown', this.onKeyDown)
+  },
   computed: {
     nodeInfo () {
       return this.$store.state.dataManager.focusNodeInfo
@@ -217,15 +223,16 @@ export default {
 }
 .data-detail-content {
   margin: 10px 5px 10px 10px;
-  height: calc(100vh - 44px - 40px - 30px - 1px - 33px - 12px - 28px);
+  height: calc(100vh - 44px - 40px - 30px - 1px - 33px - 10px - 10px - 10px - 28px);
   /* total:100vh
     header: 44px
     title: 40px
     button-bar: 30px
     border: 1px
     tab: 33px
-    tree
-    margin-bottom: 12px
+    margin-bottom: 10px
+    detail
+    margin-bottom: 10px
     footer: 28px
   */
   overflow-y: scroll;

--- a/frontend/src/views/datamanager/DataDetailHttpData.vue
+++ b/frontend/src/views/datamanager/DataDetailHttpData.vue
@@ -69,6 +69,12 @@ export default {
   beforeDestroy () {
     this.$bus.$off('keydown', this.onKeyDown)
   },
+  activated () {
+    this.$bus.$on('keydown', this.onKeyDown)
+  },
+  deactivated () {
+    this.$bus.$off('keydown', this.onKeyDown)
+  },
   computed: {
     currentTab: {
       get () {

--- a/frontend/src/views/datamanager/DataDetailPlainJSON.vue
+++ b/frontend/src/views/datamanager/DataDetailPlainJSON.vue
@@ -63,6 +63,12 @@ export default {
   beforeDestroy () {
     this.$bus.$off('keydown', this.onKeyDown)
   },
+  activated () {
+    this.$bus.$on('keydown', this.onKeyDown)
+  },
+  deactivated () {
+    this.$bus.$off('keydown', this.onKeyDown)
+  },
   computed: {
     currentTab: {
       get () {

--- a/lyrebird/checker/decoder.py
+++ b/lyrebird/checker/decoder.py
@@ -4,7 +4,7 @@ from .. import checker
 
 class CustomDecoder:
 
-    def __call__(self, rules=None, *args, **kw):
+    def __call__(self, rules=None, rank=0, *args, **kw):
         def func(origin_func):
             func_type = checker.TYPE_DECODER
             if not checker.scripts_tmp_storage.get(func_type):
@@ -12,7 +12,8 @@ class CustomDecoder:
             checker.scripts_tmp_storage[func_type].append({
                 'name': origin_func.__name__,
                 'func': origin_func,
-                'rules': rules
+                'rules': rules,
+                'rank': rank
             })
             return origin_func
         return func

--- a/lyrebird/checker/encoder.py
+++ b/lyrebird/checker/encoder.py
@@ -4,7 +4,7 @@ from .. import checker
 
 class CustomEncoder:
 
-    def __call__(self, rules=None, *args, **kw):
+    def __call__(self, rules=None, rank=0, *args, **kw):
         def func(origin_func):
             func_type = checker.TYPE_ENCODER
             if not checker.scripts_tmp_storage.get(func_type):
@@ -12,7 +12,8 @@ class CustomEncoder:
             checker.scripts_tmp_storage[func_type].append({
                 'name': origin_func.__name__,
                 'func': origin_func,
-                'rules': rules
+                'rules': rules,
+                'rank': rank
             })
             return origin_func
         return func

--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (2, 11, 0)
+IVERSION = (2, 11, 1)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION


### PR DESCRIPTION
- Fix the error that the encoder and decoder did not find the rank
- Fix the error that the shortcut key is not destroyed when switching routes
- DataManager folder details show overflow