### PR TITLE
feature/datamanager-mock-data-render-support-escape

### DIFF
--- a/lyrebird/mock/blueprints/apis/flow.py
+++ b/lyrebird/mock/blueprints/apis/flow.py
@@ -36,7 +36,6 @@ def get_flow_list_by_filter(filter_obj):
                 url=item['request'].get('url'),
                 scheme=item['request'].get('scheme'),
                 host=item['request'].get('host'),
-                port=item['request'].get('port'),
                 path=item['request'].get('path'),
                 params=unquote(urlencode(item['request']['query'])),
                 method=item['request'].get('method')
@@ -48,6 +47,10 @@ def get_flow_list_by_filter(filter_obj):
             )if item.get('response') and len(item.get('response').keys()) > 1 else {},
             action=item.get('action', [])
         )
+        # Add key `request.port` when port is not default
+        if item['request'].get('port') not in ['443', '80']:
+            info['request']['port'] = item['request'].get('port')
+
         # Add key `proxy_response` into info only if item contains proxy_response
         if item.get('proxy_response'):
             info['proxy_response'] = {

--- a/lyrebird/mock/dm/__init__.py
+++ b/lyrebird/mock/dm/__init__.py
@@ -4,6 +4,7 @@ import json
 import time
 import codecs
 import shutil
+import traceback
 from pathlib import Path
 from urllib.parse import urlparse
 from collections import OrderedDict
@@ -294,16 +295,22 @@ class DataManager:
         origin_response_data = flow['response']['data']
 
         try:
+            flow['response']['data'] = utils.render_escape_character(flow['response']['data'])
+        except Exception:
+            flow['response']['data'] = origin_response_data
+            logger.warning(f'Format response escape character error! {flow["request"]["url"]}\n {traceback.format_exc()}')
+
+        try:
             flow['response']['data'] = utils.render_data_with_tojson(flow['response']['data'])
         except Exception:
             flow['response']['data'] = origin_response_data
-            logger.warning(f'Format response string to json error! {flow["request"]["url"]}')
+            logger.warning(f'Format response string to json error! {flow["request"]["url"]}\n {traceback.format_exc()}')
 
         try:
             flow['response']['data'] = utils.render(flow['response']['data'])
         except Exception:
             flow['response']['data'] = origin_response_data
-            logger.warning(f'Format response data error! {flow["request"]["url"]}')
+            logger.warning(f'Format response data error! {flow["request"]["url"]}\n {traceback.format_exc()}')
 
     def _is_match_rule(self, flow, rules):
         return MatchRules.match(flow, rules)

--- a/lyrebird/mock/dm/__init__.py
+++ b/lyrebird/mock/dm/__init__.py
@@ -295,12 +295,6 @@ class DataManager:
         origin_response_data = flow['response']['data']
 
         try:
-            flow['response']['data'] = utils.render_escape_character(flow['response']['data'])
-        except Exception:
-            flow['response']['data'] = origin_response_data
-            logger.warning(f'Format response escape character error! {flow["request"]["url"]}\n {traceback.format_exc()}')
-
-        try:
             flow['response']['data'] = utils.render_data_with_tojson(flow['response']['data'])
         except Exception:
             flow['response']['data'] = origin_response_data

--- a/lyrebird/mock/dm/__init__.py
+++ b/lyrebird/mock/dm/__init__.py
@@ -290,7 +290,8 @@ class DataManager:
 
         return _matched_data
 
-    def _format_respose_data(self, flow):
+    @staticmethod
+    def _format_respose_data(flow):
         # TODO render mock data before response, support more functions
         origin_response_data = flow['response']['data']
 

--- a/lyrebird/utils.py
+++ b/lyrebird/utils.py
@@ -234,7 +234,6 @@ def render(data):
         'now':  datetime.datetime.now()
     }
 
-    # escape unknown canshu
     data = handle_jinja2_keywords(data, params)
 
     try:

--- a/lyrebird/utils.py
+++ b/lyrebird/utils.py
@@ -133,16 +133,6 @@ def download(link, input_path):
             f.write(chunck)
 
 
-def render_escape_character(data):
-    if not isinstance(data, str):
-        logger.warning(f'Format error! Expected str, found {type(data)}')
-        return
-
-    escape_character = ['{{', '}}']
-    for c in escape_character:
-        data.replace(c, f"{{ '{c}' }}")
-
-
 def render_data_with_tojson(data):
     config_value_tojson_key = config.get('config.value.tojsonKey')
     data_with_tojson = data
@@ -174,6 +164,18 @@ def render(data):
         'today': datetime.date.today(),
         'now':  datetime.datetime.now()
     }
+
+    # escape unknown canshu
+    findall_obj = re.findall('{{.*}}', data)
+    for target in findall_obj:
+        key = target.strip('{{').strip('}}')
+        for format_key in params.keys():
+            if key.startswith(format_key):
+                break
+        else:
+            key = target.strip('{{').strip('}}')
+            replace_str = "{{ '{{' }}" + key + "{{ '}}' }}"
+            data = data.replace(target, replace_str, 1)
 
     try:
         template_data = Template(data, keep_trailing_newline=True)

--- a/lyrebird/utils.py
+++ b/lyrebird/utils.py
@@ -132,6 +132,17 @@ def download(link, input_path):
         for chunck in resp.iter_content():
             f.write(chunck)
 
+
+def render_escape_character(data):
+    if not isinstance(data, str):
+        logger.warning(f'Format error! Expected str, found {type(data)}')
+        return
+
+    escape_character = ['{{', '}}']
+    for c in escape_character:
+        data.replace(c, f"{{ '{c}' }}")
+
+
 def render_data_with_tojson(data):
     config_value_tojson_key = config.get('config.value.tojsonKey')
     data_with_tojson = data
@@ -149,6 +160,7 @@ def render_data_with_tojson(data):
         pattern_group = '(' + pattern + ')'
         data_with_tojson = re.sub('("{{)'+pattern_group+'(}}")', r'{{\2 | tojson}}', data_with_tojson)
     return data_with_tojson
+
 
 def render(data):
     if not isinstance(data, str):
@@ -168,6 +180,7 @@ def render(data):
         return template_data.render(params)
     except Exception:
         logger.error(f'Format error!\n {traceback.format_exc()}')
+        return data
 
 
 class CaseInsensitiveDict(dict):

--- a/lyrebird/utils.py
+++ b/lyrebird/utils.py
@@ -221,7 +221,7 @@ def handle_jinja2_keywords(data, params=None):
 def render(data):
     if not isinstance(data, str):
         logger.warning(f'Format error! Expected str, found {type(data)}')
-        return data
+        return
 
     params = {
         'config': config,
@@ -238,7 +238,6 @@ def render(data):
         return template_data.render(params)
     except Exception:
         logger.error(f'Format error!\n {traceback.format_exc()}')
-        return data
 
 
 def get_query_array(url):

--- a/lyrebird/utils.py
+++ b/lyrebird/utils.py
@@ -184,11 +184,9 @@ def handle_jinja2_keywords(data, params=None):
 
     left_pattern_index = None
     for index, item in enumerate(item_list):
-        if index%2:
+        if index % 2:
             # 1. Handle more than 2 big brackets
-            if len(item) > 2:
-                item_list[index] = "{{ '%s' }}" % (item)
-            elif item not in keywords_pair:
+            if (len(item) > 2) or (item not in keywords_pair):
                 item_list[index] = "{{ '%s' }}" % (item)
             else:
                 left_pattern_index = index
@@ -211,11 +209,10 @@ def handle_jinja2_keywords(data, params=None):
             key_n_lefted = item.split('}}', 1)
             if len(key_n_lefted) != 2:
                 continue
-            key, lefted = key_n_lefted
+            key, _ = key_n_lefted
             if [key for p in params if key.startswith(p)]:
                 continue
             item_list[index-1] = "{{ '%s' }}" % (item_list[index-1])
-            item_list[index] = "%s{{ '}}' }}%s" % (key, lefted)
 
     after_data = ''.join(item_list)
     return after_data

--- a/lyrebird/utils.py
+++ b/lyrebird/utils.py
@@ -159,7 +159,7 @@ def handle_jinja2_keywords(data, params=None):
 
     Handle 3 kinds of unexpected left brackets:
     1. More than 2 big brackets              `{{{ }}}` `{{# #}}` `{{% %}}`
-    2. Mismatched keyword                    `{{{` `{{#}}` `{{%`
+    2. Mismatched keyword                    `{{{` `{{#` `{{%`
     3. Unknown arguments between {{ and }}   `{{unknown}}`
 
     Convert unexpected brackets into presentable string in Jinja2, such as `var` -> `{{ 'var' }}`

--- a/tests/test_dm_format.py
+++ b/tests/test_dm_format.py
@@ -111,7 +111,7 @@ def test_format_empty_parameter(config):
     assert data == response_data_str
 
 
-def test_format_with_mismatched_keyword(config):
+def test_format_with_mismatched_left_keyword(config):
     mismatched_str = ' ip {{ip {%ip {#ip'
     response_data_str = '{{ip}}' + mismatched_str
     flow = {
@@ -122,6 +122,18 @@ def test_format_with_mismatched_keyword(config):
     DataManager._format_respose_data(flow)
     data = flow['response']['data']
     assert data == f'127.0.0.1{mismatched_str}'
+
+
+def test_format_with_mismatched_right_keyword(config):
+    response_data_str = ' ip ip}} }} ip%} ip#}'
+    flow = {
+        'response': {
+            'data': response_data_str
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == response_data_str
 
 
 def test_format_with_more_than_2_big_brackets(config):
@@ -137,7 +149,7 @@ def test_format_with_more_than_2_big_brackets(config):
 
 
 def test_format_unknown_parameter(config):
-    response_data_str = '{{unknown}}{{unknown}}{{unknown2}}'
+    response_data_str = '{{unknown}} content {{unknown}} content {{unknown2}}'
     flow = {
         'response': {
             'data': response_data_str

--- a/tests/test_dm_format.py
+++ b/tests/test_dm_format.py
@@ -1,0 +1,148 @@
+import re
+import pytest
+from lyrebird import application
+from lyrebird.mock.dm import DataManager
+from lyrebird.config import ConfigManager
+
+
+@pytest.fixture
+def config():
+    _conf = {
+        'ip': '127.0.0.1',
+        'mock.port': 9090,
+        'custom_key': 'custom_value',
+        'config.value.tojsonKey': ['custom.[a-z0-9]{8}(-[a-z0-9]{4}){3}-[a-z0-9]{12}'],
+        'custom.8df051be-4381-41b6-9252-120d9b558bf6': {"custom_key": "custom_value"}
+    }
+    application._cm = ConfigManager()
+    application._cm.config = _conf
+
+
+def test_format_ip(config):
+    flow = {
+        'response': {
+            'data': '{{ip}}'
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == '127.0.0.1'
+
+
+def test_format_port(config):
+    flow = {
+        'response': {
+            'data': '{{port}}'
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == '9090'
+
+
+def test_format_config(config):
+    flow = {
+        'response': {
+            'data': "{{config.get('custom_key')}}"
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == 'custom_value'
+
+
+def test_format_today(config):
+    flow = {
+        'response': {
+            'data': '{{today}}'
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert re.fullmatch(r'\d{4}-\d{2}-\d{2}', data)
+
+
+def test_format_today(config):
+    flow = {
+        'response': {
+            'data': "{{now.strftime('%Y-%m-%d %H:%M:%S')}}"
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert re.fullmatch(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}', data)
+
+
+def test_format_tojson(config):
+    flow = {
+        'response': {
+            'data': '"keyA":"valueA","keyB":"{{config.get(\'custom.8df051be-4381-41b6-9252-120d9b558bf6\')}}","keyC":"valueC"'
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert '"keyA":"valueA"' in data
+    assert '"keyB":{"custom_key": "custom_value"}' in data
+    assert '"keyC":"valueC"' in data
+
+
+
+def test_format_no_param(config):
+    response_data_str = 'ip'
+    flow = {
+        'response': {
+            'data': response_data_str
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == response_data_str
+
+
+def test_format_empty_parameter(config):
+    response_data_str = '{{}}'
+    flow = {
+        'response': {
+            'data': response_data_str
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == response_data_str
+
+
+def test_format_with_mismatched_keyword(config):
+    mismatched_str = ' ip {{ip {%ip {#ip'
+    response_data_str = '{{ip}}' + mismatched_str
+    flow = {
+        'response': {
+            'data': response_data_str
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == f'127.0.0.1{mismatched_str}'
+
+
+def test_format_with_more_than_2_big_brackets(config):
+    response_data_str = '{{{ ip }}} {{{{ ip }}}} {{% loop %}} {{# comment #}}'
+    flow = {
+        'response': {
+            'data': response_data_str
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == response_data_str
+
+
+def test_format_unknown_parameter(config):
+    response_data_str = '{{unknown}}{{unknown}}{{unknown2}}'
+    flow = {
+        'response': {
+            'data': response_data_str
+        }
+    }
+    DataManager._format_respose_data(flow)
+    data = flow['response']['data']
+    assert data == response_data_str


### PR DESCRIPTION
- escape keywords in jinja2, such as {{ }}